### PR TITLE
feat: upgrade to latest redocly cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/openapi-cli
+FROM redocly/cli
 
 COPY LICENSE.md README.md /
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # redocly-openapi-cli-github-action
 
-#### A Github action for running redocly openapi-cli commands
+#### A Github action for running Redocly CLI commands
 
 ## :keyboard: Inputs
 
 ### `args`
 
-The arguments to be provided to the redocly `openapi` cli command.
-By default this is empty so that redocly `openapi` cli will print a note about its correct usage.
+The arguments to be provided to the `redocly` cli command.
+By default this is empty so that `redocly` cli will print a note about its correct usage.
 
 ## :bulb: Quick Start
 
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: openapi bundle
+      - name: redocly bundle
         uses: trybeapp/redocly-openapi-cli-github-action@v0.0.1
         with:
           args: 'bundle test/petstore.yml'
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: openapi lint
+      - name: redocly lint
         uses: trybeapp/redocly-openapi-cli-github-action@v0.0.1
         with:
           args: 'lint test/petstore.yml'
@@ -49,4 +49,4 @@ This example validates your OpenAPI definition files to ensure they do not conta
 
 ## :blue_book: References
 
-- [Redocly OpenAPI CLI](https://redoc.ly/docs/cli/)
+- [Redocly CLI](https://redoc.ly/docs/cli/)

--- a/action.yaml
+++ b/action.yaml
@@ -1,16 +1,16 @@
-name: 'OpenAPI CLI Github Action'
-description: 'A wrapper around the redocly openapi-cli for linting and bundling OpenAPI definitions.'
+name: 'Redocly CLI Github Action'
+description: 'A wrapper around the Redocly cli for linting and bundling OpenAPI definitions.'
 branding:
   icon: align-justify
   color: 'purple'
 inputs:
   args:
-    description: 'The arguments to pass to the openapi-cli'
+    description: 'The arguments to pass to the redocly'
     required: false
     default: ''
 outputs:
   output:
-    description: 'The output of the openapi-cli command'
+    description: 'The output of the redocly command'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,4 +8,4 @@ echo "redocly version: $(redocly --version)"
 
 output=$(redocly $1)
 
-echo "::set-output name=output::$output"
+echo "{output}={$output}" >> $GITHUB_OUTPUT

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,8 +4,8 @@ set -o pipefail
 
 cd /github/workspace
 
-echo "openapi-cli version: $(openapi --version)"
+echo "redocly version: $(redocly --version)"
 
-output=$(openapi $1)
+output=$(redocly $1)
 
 echo "::set-output name=output::$output"

--- a/test/petstore-full.yaml
+++ b/test/petstore-full.yaml
@@ -6,6 +6,7 @@ info:
     name: MIT
 servers:
   - url: http://petstore.swagger.io/v1
+security: []
 paths:
   /pets:
     get:

--- a/test/petstore.yaml
+++ b/test/petstore.yaml
@@ -6,6 +6,7 @@ info:
     name: MIT
 servers:
   - url: http://petstore.swagger.io/v1
+security: []
 paths:
   /pets:
     get:


### PR DESCRIPTION
Hi, I found out that Redocly changed a few things, and they now use a different docker image and command name.